### PR TITLE
This and that

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,3 +9,4 @@
 - Add software tests
 - CLI: Add `mlflow-cratedb cratedb --version` command
 - Project: Add `versioningit`, for effortless versioning
+- Add patch for SQLAlchemy Inspector's `get_table_names`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,3 +8,4 @@
 - Initial thing, proof-of-concept
 - Add software tests
 - CLI: Add `mlflow-cratedb cratedb --version` command
+- Project: Add `versioningit`, for effortless versioning

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,3 +10,4 @@
 - CLI: Add `mlflow-cratedb cratedb --version` command
 - Project: Add `versioningit`, for effortless versioning
 - Add patch for SQLAlchemy Inspector's `get_table_names`
+- Reorder CrateDB SQLAlchemy Dialect polyfills

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,4 +5,5 @@
 
 
 ## 2023-09-xx 0.0.0
-- Initial thing
+- Initial thing, proof-of-concept
+- Add software tests

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,3 +7,4 @@
 ## 2023-09-xx 0.0.0
 - Initial thing, proof-of-concept
 - Add software tests
+- CLI: Add `mlflow-cratedb cratedb --version` command

--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ Install the most recent version of the `mlflow-cratedb` package.
 pip install --upgrade 'git+https://github.com/crate-workbench/mlflow-cratedb'
 ```
 
+To verify if the installation worked, you can inspect the version numbers
+of the software components you just installed.
+```shell
+mlflow-cratedb --version
+mlflow-cratedb cratedb --version
+```
+
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,18 @@ pytest -m slow
 ```
 
 
+## Acknowledgements
+
+[Siddharth Murching], [Corey Zumar], [Harutaka Kawamura], [Ben Wilson], and
+all other contributors for conceiving and maintaining [MLflow].
+
+
+
+[Ben Wilson]: https://github.com/BenWilson2
+[Corey Zumar]: https://github.com/dbczumar
 [CrateDB]: https://github.com/crate/crate
 [CrateDB Cloud]: https://console.cratedb.cloud/
+[Harutaka Kawamura]: https://github.com/harupy
 [MLflow]: https://mlflow.org/
 [MLflow Tracking]: https://mlflow.org/docs/latest/tracking.html
+[Siddharth Murching]: https://github.com/smurching

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,7 +1,6 @@
 # Backlog
 
 ## Iteration +1
-- Add `versioningit`
 - CLI shortcut for `ddl/drop.sql`
 - Add example `tracking_merlion.py`
 - Integrate tutorial from `cratedb-examples`
@@ -15,3 +14,4 @@
 
 ## Done
 - Use or provide wheel packages for `hashids` and `vasuki`
+- Add `versioningit`

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,7 +1,17 @@
 # Backlog
 
-- Provide wheel packages for `hashids` and `vasuki`
+## Iteration +1
+- Add `versioningit`
+- CLI shortcut for `ddl/drop.sql`
+- Add example `tracking_merlion.py`
+- Integrate tutorial from `cratedb-examples`
+- Add GHA recipe to build and ship OCI image
+- Release 0.1.0
+
+## Iteration +2
 - Demonstrate use of `--backend=databricks`
 - Run an MLflow project from the given URI, using `mlflow run`
-- Explore `mlflow experiments search` for testing purposes
-- CLI shortcut for `ddl/drop.sql`
+- Explore `mlflow experiments search`
+
+## Done
+- Use or provide wheel packages for `hashids` and `vasuki`

--- a/mlflow_cratedb/cli.py
+++ b/mlflow_cratedb/cli.py
@@ -1,2 +1,14 @@
+import importlib.metadata
+
+import click
+
 # Intercept CLI entrypoint for monkeypatching.
 from mlflow.cli import cli  # noqa: F401
+
+app_version = importlib.metadata.version("mlflow-cratedb")
+
+
+@cli.command("cratedb")
+@click.version_option(version=app_version)
+def cratedb():
+    pass

--- a/mlflow_cratedb/patch/mlflow/__init__.py
+++ b/mlflow_cratedb/patch/mlflow/__init__.py
@@ -12,10 +12,10 @@ def patch_mlflow():
     Patch the MLflow package.
     """
     patch_dbtypes()
-    polyfill_refresh_after_dml()
-    polyfill_uniqueness_constraints()
     patch_db_utils()
     patch_run_server()
     patch_environment_variables()
     patch_search_utils()
     patch_tracking()
+    polyfill_uniqueness_constraints()
+    polyfill_refresh_after_dml()

--- a/mlflow_cratedb/patch/mlflow/__init__.py
+++ b/mlflow_cratedb/patch/mlflow/__init__.py
@@ -13,9 +13,9 @@ def patch_mlflow():
     """
     patch_dbtypes()
     patch_db_utils()
+    polyfill_refresh_after_dml()
+    polyfill_uniqueness_constraints()
     patch_run_server()
     patch_environment_variables()
     patch_search_utils()
     patch_tracking()
-    polyfill_uniqueness_constraints()
-    polyfill_refresh_after_dml()

--- a/mlflow_cratedb/patch/mlflow/db_utils.py
+++ b/mlflow_cratedb/patch/mlflow/db_utils.py
@@ -6,6 +6,7 @@ import sqlalchemy as sa
 def patch_db_utils():
     import mlflow.store.db.utils as db_utils
 
+    patch_create_sqlalchemy_engine()
     db_utils._initialize_tables = _initialize_tables
     db_utils._verify_schema = _verify_schema
 
@@ -29,3 +30,27 @@ def _verify_schema(engine: sa.Engine):
     Skipping Alembic, that's a no-op.
     """
     pass
+
+
+def patch_create_sqlalchemy_engine():
+    """
+    MLflow's SqlAlchemyStore objects invoke `_all_tables_exist()`, which in turn
+    invoke SQLAlchemy Inspector's `get_table_names()`, which apparently does not
+    honor the `schema` parameter.
+
+    This leads to MLflow failing on server startup::
+
+        mlflow.exceptions.MlflowException: Database migration in unexpected state. Run manual upgrade.
+    """
+    import mlflow.store.db.utils as db_utils
+
+    create_sqlalchemy_engine_dist = db_utils.create_sqlalchemy_engine
+
+    def create_sqlalchemy_engine(db_uri):
+        from mlflow_cratedb.patch.sqlalchemy import patch_sqlalchemy_inspector
+
+        engine = create_sqlalchemy_engine_dist(db_uri=db_uri)
+        patch_sqlalchemy_inspector(engine)
+        return engine
+
+    db_utils.create_sqlalchemy_engine = create_sqlalchemy_engine

--- a/mlflow_cratedb/patch/sqlalchemy.py
+++ b/mlflow_cratedb/patch/sqlalchemy.py
@@ -1,0 +1,25 @@
+import typing as t
+
+import sqlalchemy as sa
+
+
+def patch_sqlalchemy_inspector(engine: sa.Engine):
+    """
+    When using `get_table_names()`, make sure the correct schema name gets used.
+
+    Apparently, SQLAlchemy does not honor the `search_path` of the engine, when
+    using the inspector?
+
+    TODO: Submit this to SQLAlchemy?
+    """
+    get_table_names_dist = engine.dialect.get_table_names
+    schema_name = engine.url.query.get("schema")
+    if isinstance(schema_name, tuple):
+        schema_name = schema_name[0]
+
+    def get_table_names(connection: sa.Connection, schema: t.Optional[str] = None, **kw: t.Any) -> t.List[str]:
+        if schema is None:
+            schema = schema_name
+        return get_table_names_dist(connection=connection, schema=schema, **kw)
+
+    engine.dialect.get_table_names = get_table_names  # type: ignore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ license = {text = "Apache License 2.0"}
 keywords = [
   "cratedb",
   "machine learning",
+  "ml-ops",
   "mlflow",
   "mlflow-tracking",
   "mlops",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,19 @@
 
 # Derived from https://peps.python.org/pep-0621/
 
+[build-system]
+build-backend = "setuptools.build_meta"
+requires = [
+  "setuptools>=42", # At least v42 of setuptools required.
+  "versioningit",
+]
+
+[tool.versioningit.vcs]
+method = "git"
+default-tag = "0.0.0"
+
 [project]
 name = "mlflow-cratedb"
-version = "0.0.0"
 description = "MLflow adapter for CrateDB"
 readme = "README.md"
 requires-python = ">=3.8"
@@ -44,6 +54,10 @@ classifiers = [
   "Topic :: Education",
   "Topic :: Software Development :: Libraries",
   "Topic :: Utilities",
+]
+
+dynamic = [
+  "version",
 ]
 
 dependencies = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,15 @@
+import mlflow
+import pytest
+
 from mlflow_cratedb import patch_all
 
 patch_all()
+
+
+# The canonical database schema used for test purposes is `testdrive`.
+DB_URI = "crate://crate@localhost/?schema=testdrive"
+
+
+@pytest.fixture
+def testdrive_engine():
+    yield mlflow.store.db.utils.create_sqlalchemy_engine_with_retry(DB_URI)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,26 @@
+from click.testing import CliRunner
+
+from mlflow_cratedb.cli import cli
+
+
+def test_versions():
+    """
+    CLI test: Invoke `mlflow-cratedb --version` and `mlflow-cratedb cratedb --version`
+    """
+    runner = CliRunner()
+
+    result = runner.invoke(cli, args="--version", catch_exceptions=False)
+    assert result.exit_code == 0
+
+    result = runner.invoke(cli, args="cratedb --version", catch_exceptions=False)
+    assert result.exit_code == 0
+
+
+def test_unknown_parameter():
+    """
+    CLI test: Invoke `mlflow-cratedb --foo`.
+    """
+    runner = CliRunner()
+
+    result = runner.invoke(cli, args="foo", catch_exceptions=False)
+    assert result.exit_code == 2

--- a/tests/test_mlflow.py
+++ b/tests/test_mlflow.py
@@ -1,0 +1,14 @@
+import mlflow
+
+from mlflow_cratedb.adapter.setup_db import _setup_db_create_tables, _setup_db_drop_tables
+
+
+def test_all_tables_exist(testdrive_engine):
+    """
+    Cover `patch_sqlalchemy_inspector`: SQLAlchemy's Inspector
+    needs a patch to honor the `schema` parameter.
+    """
+    _setup_db_drop_tables(engine=testdrive_engine)
+    assert mlflow.store.db.utils._all_tables_exist(testdrive_engine) is False
+    _setup_db_create_tables(engine=testdrive_engine)
+    assert mlflow.store.db.utils._all_tables_exist(testdrive_engine) is True


### PR DESCRIPTION
## About

A few more improvements on different ends.

### Level 1
- Add patch for SQLAlchemy Inspector's `get_table_names` again. Contrary to the latest assessment, we still need it, see below.

### Level 2
- CLI: Add `mlflow-cratedb cratedb --version` command
- Project: Add `versioningit`, for effortless versioning
- Tests: Provide fixture `testdrive_engine` for the whole test suite
- Reorder CrateDB SQLAlchemy Dialect polyfills
- Update documentation