### PR TITLE
Last minute updates to the documentation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 
 ## in progress
-
+- Documentation: Improve "Container Usage" page 
 
 ## 2023-09-12 0.1.0
 - Initial thing, proof-of-concept

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 
 ## in progress
 - Documentation: Improve "Container Usage" page 
+- Documentation: Update README with real `pip install` command
 
 ## 2023-09-12 0.1.0
 - Initial thing, proof-of-concept

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ experimentation, reproducibility, deployment, and a central model registry.
 
 Install the most recent version of the `mlflow-cratedb` package.
 ```shell
-pip install --upgrade 'git+https://github.com/crate-workbench/mlflow-cratedb#egg=mlflow-cratedb[examples]'
+pip install --upgrade 'mlflow-cratedb[examples]'
 ```
 
 To verify if the installation worked, you can inspect the version numbers


### PR DESCRIPTION
## About

On the 0.1.0 release, I forgot to correctly state `pip install --upgrade 'mlflow-cratedb[examples]'` in the README.

While already editing the documentation, and verifying that all steps work which have been written down in [docs/container.md](https://github.com/crate-workbench/mlflow-cratedb/blob/main/docs/container.md), I've improved it a bit more to be a coherent and self-contained walkthrough.
