### PR TITLE
SQLAlchemy: Use server-side `now()` function for "autoincrement" columns

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 ## in progress
 - Update to MLflow 2.7.1
 - Improve `table_exists()` in `example_merlion.py`
+- SQLAlchemy: Use server-side `now()` function for "autoincrement" columns
 
 ## 2023-09-12 0.1.1
 - Documentation: Improve "Container Usage" page

--- a/mlflow_cratedb/patch/crate_python.py
+++ b/mlflow_cratedb/patch/crate_python.py
@@ -15,6 +15,7 @@ def patch_models():
           dialect parameter `crate_polyfill_autoincrement` or such.
     """
     import sqlalchemy.sql.schema as schema
+    from sqlalchemy import func
 
     init_dist = schema.Column.__init__
 
@@ -22,7 +23,7 @@ def patch_models():
         if "autoincrement" in kwargs:
             del kwargs["autoincrement"]
             if "default" not in kwargs:
-                kwargs["default"] = generate_unique_integer
+                kwargs["default"] = func.now()
         init_dist(self, *args, **kwargs)
 
     schema.Column.__init__ = __init__  # type: ignore[method-assign]
@@ -104,12 +105,3 @@ def check_uniqueness_factory(sa_entity, attribute_name):
                 )
 
     return check_uniqueness
-
-
-def generate_unique_integer() -> int:
-    """
-    Produce a short, unique, non-sequential identifier based on Hashids.
-    """
-    from vasuki import generate_nagamani19_int
-
-    return generate_nagamani19_int()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,6 @@ dependencies = [
   "crate[sqlalchemy]",
   "mlflow==2.7.1",
   "sqlparse<0.5",
-  "vasuki<1,>=0.4",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Now uses the server-side `now()` function to patch column models using the "autoincrement" property, as suggested by @seut at https://github.com/crate/crate-python/issues/575#issuecomment-1723030490. Thanks!