### PR TITLE
Add pycaret automl timeseries forecasting mlflow-cratedb example (currently only python 3.10)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.11"]
+        python-version: ["3.10"]
 
     env:
       OS: ${{ matrix.os }}

--- a/.github/workflows/oci-server.yml
+++ b/.github/workflows/oci-server.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.10"
           architecture: "x64"
           cache: "pip"
           cache-dependency-path: "pyproject.toml"

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ __pycache__
 /mlartifacts
 /mlruns
 /model
+logs.log
+catboost_info/

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,18 +6,18 @@
 - Downgrade to Python 3.10. A few packages like PyCaret are not ready for
   Python 3.11 yet. Thanks, @andnig.
 
-## 2023-10-11 0.2.0
+## 2023-10-11 v0.2.0
 - Update to [MLflow 2.7](https://github.com/mlflow/mlflow/releases/tag/v2.7.0)
 - Improve `table_exists()` in `example_merlion.py`
 - SQLAlchemy: Use server-side `now()` function for "autoincrement" columns
 - Use SQLAlchemy patches and polyfills from `cratedb-toolkit`
 - Update and improve documentation
 
-## 2023-09-12 0.1.1
+## 2023-09-12 v0.1.1
 - Documentation: Improve "Container Usage" page
 - Documentation: Update README with real `pip install` command
 
-## 2023-09-12 0.1.0
+## 2023-09-12 v0.1.0
 - Initial thing, proof-of-concept
 - Add software tests
 - CLI: Add `mlflow-cratedb cratedb --version` command

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 
 ## in progress
+- Fix uniqueness constraint with `SqlRegisteredModel.name`. Thanks, @andnig.
 
 ## 2023-10-11 0.2.0
 - Update to [MLflow 2.7](https://github.com/mlflow/mlflow/releases/tag/v2.7.0)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 
 ## in progress
+
+## 2023-11-01 v2.7.1
 - Fix uniqueness constraint with `SqlRegisteredModel.name`. Thanks, @andnig.
 - Downgrade to Python 3.10. A few packages like PyCaret are not ready for
   Python 3.11 yet. Thanks, @andnig.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@
 
 ## in progress
 - Fix uniqueness constraint with `SqlRegisteredModel.name`. Thanks, @andnig.
+- Downgrade to Python 3.10. A few packages like PyCaret are not ready for
+  Python 3.11 yet. Thanks, @andnig.
 
 ## 2023-10-11 0.2.0
 - Update to [MLflow 2.7](https://github.com/mlflow/mlflow/releases/tag/v2.7.0)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 
 ## in progress
+- Update to MLflow 2.8.0
 
 ## 2023-11-01 v2.7.1
 - Fix uniqueness constraint with `SqlRegisteredModel.name`. Thanks, @andnig.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 
 ## in progress
 - Update to MLflow 2.8.0
+- Fix uniqueness constraint with `mlflow.server.auth.db.models.SqlUser.username`.
 
 ## 2023-11-01 v2.7.1
 - Fix uniqueness constraint with `SqlRegisteredModel.name`. Thanks, @andnig.

--- a/examples/tracking_pycaret.py
+++ b/examples/tracking_pycaret.py
@@ -74,6 +74,18 @@ def table_exists(table_name: str) -> bool:
     conn.close()
     return rowcount > 0
 
+def data_available(table_name: str) -> bool:
+    """
+    Check if data is available in database table.
+    """
+    conn = connect_database()
+    cursor = conn.cursor()
+    sql = f"SELECT count(*) FROM {table_name}"  # noqa: S608
+    cursor.execute(sql)
+    rowcount = cursor.fetchone()[0]
+    cursor.close()
+    conn.close()
+    return rowcount > 0
 
 def import_data(data_table_name: str):
     """

--- a/examples/tracking_pycaret.py
+++ b/examples/tracking_pycaret.py
@@ -74,6 +74,7 @@ def table_exists(table_name: str) -> bool:
     conn.close()
     return rowcount > 0
 
+
 def import_data(data_table_name: str):
     """
     Download Real-world sales forecasting benchmark data, and load into database.
@@ -128,6 +129,7 @@ def refresh_table(table_name: str):
         cursor = conn.cursor()
         cursor.execute(f"REFRESH TABLE {table_name}")
         cursor.close()
+
 
 def read_data(table_name: str) -> pd.DataFrame:
     """

--- a/examples/tracking_pycaret.py
+++ b/examples/tracking_pycaret.py
@@ -1,0 +1,195 @@
+"""
+About
+
+Use MLflow and CrateDB to track the metrics, parameters, and outcomes of an ML
+experiment program using PyCaret. It uses the Real-world sales forecasting benchmark data
+dataset from 4TU.ResearchData.
+
+- https://github.com/crate-workbench/mlflow-cratedb
+- https://mlflow.org/docs/latest/tracking.html
+
+Usage
+
+Before running the program, optionally define the `MLFLOW_TRACKING_URI` environment
+variable, in order to record events and metrics either directly into the database,
+or by submitting them to an MLflow Tracking Server.
+
+    # Use CrateDB database directly
+    export MLFLOW_TRACKING_URI="crate://crate@localhost/?schema=mlflow"
+
+    # Use MLflow Tracking Server
+    export MLFLOW_TRACKING_URI=http://127.0.0.1:5000
+
+Resources
+
+- https://mlflow.org/
+- https://github.com/crate/crate
+- https://github.com/pycaret/pycaret
+- https://data.4tu.nl/articles/dataset/Real-world_sales_forecasting_benchmark_data_-_Extended_version/14406134/1
+"""
+
+import os
+import time
+
+import numpy as np
+import pandas as pd
+from crate import client
+from mlflow import get_tracking_uri
+from mlflow.models import infer_signature
+from mlflow.sklearn import log_model
+from pycaret.time_series import blend_models, compare_models, finalize_model, save_model, setup, tune_model
+
+import mlflow_cratedb  # noqa: F401
+
+
+def connect_database():
+    """
+    Connect to CrateDB, and return database connection object.
+    """
+    dburi = os.getenv("CRATEDB_HTTP_URL", "http://crate@localhost:4200")
+    return client.connect(dburi)
+
+
+def table_exists(table_name: str) -> bool:
+    """
+    Check if database table exists.
+    """
+    conn = connect_database()
+    cursor = conn.cursor()
+    sql = (
+        f"SELECT table_name FROM information_schema.tables "  # noqa: S608
+        f"WHERE table_name = '{table_name}' AND table_schema = CURRENT_SCHEMA"
+    )
+    cursor.execute(sql)
+    rowcount = cursor.rowcount
+    cursor.close()
+    conn.close()
+    return rowcount > 0
+
+
+def import_data(data_table_name: str):
+    """
+    Download Real-world sales forecasting benchmark data, and load into database.
+    """
+
+    target_data = pd.read_csv(
+        "https://data.4tu.nl/file/539debdb-a325-412d-b024-593f70cba15b/a801f5d4-5dfe-412a-ace2-a64f93ad0010"
+    )
+    related_data = pd.read_csv(
+        "https://data.4tu.nl/file/539debdb-a325-412d-b024-593f70cba15b/f2bd27bd-deeb-4933-bed7-29325ee05c2e",
+        header=None,
+    )
+    related_data.columns = ["item", "org", "date", "unit_price"]
+    data = target_data.merge(related_data, on=["item", "org", "date"])
+    data["total_sales"] = data["unit_price"] * data["quantity"]
+    data["date"] = pd.to_datetime(data["date"])
+
+    # Split the data into chunks of 1000 rows each for better insert performance
+    chunk_size = 1000
+    chunks = np.array_split(data, int(len(data) / chunk_size))
+
+    # Insert the data into CrateDB
+    with connect_database() as conn:
+        cursor = conn.cursor()
+        # Create the table if it doesn't exist
+        cursor.execute(f"""CREATE TABLE IF NOT EXISTS {data_table_name}
+            ("item" TEXT,
+            "org" TEXT,
+            "date" TIMESTAMP,
+            "quantity" BIGINT,
+            "unit_price" DOUBLE PRECISION,
+            "total_sales" DOUBLE PRECISION)""")
+
+        # Insert the data in chunks
+        for chunk in chunks:
+            cursor.executemany(
+                f"""INSERT INTO {data_table_name}
+                (item, org, date, quantity, unit_price, total_sales)
+                VALUES (?, ?, ?, ?, ?, ?)""",  # noqa: S608
+                list(chunk.itertuples(index=False, name=None)),
+            )
+
+
+def read_data(table_name: str) -> pd.DataFrame:
+    """
+    Read data from database into pandas DataFrame.
+    """
+
+    query = f"""
+            SELECT
+                DATE_TRUNC('month', date) as month,
+                SUM(total_sales) AS total_sales
+            FROM {table_name}
+            GROUP BY month
+            ORDER BY month
+        """
+    with connect_database() as conn:
+        data = pd.read_sql(query, conn)
+
+    data["month"] = pd.to_datetime(data["month"], unit="ms")
+    data.sort_values(by=["month"], inplace=True)
+    return data
+
+
+def run_experiment(data: pd.DataFrame):
+    """
+    Run experiment on DataFrame, using PyCaret. Track it using MLflow.
+    The mlflow tracking is automatically executed by PyCaret.
+    """
+
+    # creating a blend of 3 models, which perform best on MASE metric
+    pycaret_setup = setup(data,
+                          fh=15,
+                          target="total_sales",
+                          index="month",
+                          log_experiment=True,
+                          verbose=False)
+    best3 = compare_models(sort="MASE", n_select=3)
+    tuned_models = [tune_model(i) for i in best3]
+    blended = blend_models(estimator_list=tuned_models, optimize="MASE")
+    best_model = finalize_model(blended)
+
+    # saving the model to disk
+    if not os.path.exists("model"):
+        os.makedirs("model")
+    save_model(best_model, 'model/crate-salesforecast')
+
+    # Create a name for the model
+    timestamp = int(time.time())
+
+    # registering the model with mlflow, but only if MLFLOW_TRACKING_URI is
+    # set to a tracking server
+    if not get_tracking_uri().startswith("file://"):
+        y_pred = best_model.predict()
+        signature = infer_signature(None, y_pred)
+        log_model(
+            sk_model=best_model,
+            artifact_path="crate-salesforecast",
+            signature=signature,
+            registered_model_name=f"crate-salesforecast-model-{timestamp}",
+        )
+    else:
+        print("MLFLOW_TRACKING_URI is not set to a tracking server, "  # noqa: T201
+              "so the model will not be registered with mlflow")
+
+def main():
+    """
+    Provision dataset, and run experiment.
+    """
+
+    # Table name where the actual data is stored.
+    data_table = "sales_data_for_forecast"
+
+    # Provision data to operate on, only once.
+    if not table_exists(data_table):
+        import_data(data_table)
+
+    # Read data into pandas DataFrame.
+    data = read_data(data_table)
+
+    # Run experiment on data.
+    run_experiment(data)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/tracking_pycaret.py
+++ b/examples/tracking_pycaret.py
@@ -142,7 +142,6 @@ def refresh_table(table_name: str):
         cursor.execute(f"REFRESH TABLE {table_name}")
         cursor.close()
 
-
 def read_data(table_name: str) -> pd.DataFrame:
     """
     Read data from database into pandas DataFrame.

--- a/examples/tracking_pycaret.py
+++ b/examples/tracking_pycaret.py
@@ -10,7 +10,7 @@ dataset from 4TU.ResearchData.
 
 Usage
 
-Before running the program, optionally define the `MLFLOW_TRACKING_URI` environment
+Before running the program, define the `MLFLOW_TRACKING_URI` environment
 variable, in order to record events and metrics either directly into the database,
 or by submitting them to an MLflow Tracking Server.
 

--- a/examples/tracking_pycaret.py
+++ b/examples/tracking_pycaret.py
@@ -191,7 +191,6 @@ def run_experiment(data: pd.DataFrame):
             "MLFLOW_TRACKING_URI is not set to a tracking server, "
             "so the model will not be registered with mlflow")
 
-
 def main():
     """
     Provision dataset, and run experiment.

--- a/examples/tracking_pycaret.py
+++ b/examples/tracking_pycaret.py
@@ -160,12 +160,7 @@ def run_experiment(data: pd.DataFrame):
     """
 
     # creating a blend of 3 models, which perform best on MASE metric
-    setup(data,
-          fh=15,
-          target="total_sales",
-          index="month",
-          log_experiment=True,
-          verbose=False)
+    setup(data, fh=15, target="total_sales", index="month", log_experiment=True, verbose=False)
 
     best3 = compare_models(sort="MASE", n_select=3)
     tuned_models = [tune_model(i) for i in best3]
@@ -193,8 +188,8 @@ def run_experiment(data: pd.DataFrame):
         )
     else:
         print(  # noqa: T201
-            "MLFLOW_TRACKING_URI is not set to a tracking server, "
-            "so the model will not be registered with mlflow")
+            "MLFLOW_TRACKING_URI is not set to a tracking server, so the model will not be registered with mlflow"
+        )
 
 def main():
     """

--- a/examples/tracking_pycaret.py
+++ b/examples/tracking_pycaret.py
@@ -74,19 +74,6 @@ def table_exists(table_name: str) -> bool:
     conn.close()
     return rowcount > 0
 
-def data_available(table_name: str) -> bool:
-    """
-    Check if data is available in database table.
-    """
-    conn = connect_database()
-    cursor = conn.cursor()
-    sql = f"SELECT count(*) FROM {table_name}"  # noqa: S608
-    cursor.execute(sql)
-    rowcount = cursor.fetchone()[0]
-    cursor.close()
-    conn.close()
-    return rowcount > 0
-
 def import_data(data_table_name: str):
     """
     Download Real-world sales forecasting benchmark data, and load into database.

--- a/mlflow_cratedb/adapter/ddl/cratedb.sql
+++ b/mlflow_cratedb/adapter/ddl/cratedb.sql
@@ -72,6 +72,7 @@ CREATE TABLE IF NOT EXISTS "model_versions" (
    "user_id" TEXT,
    "current_stage" TEXT,
    "source" TEXT,
+   "storage_location" TEXT,
    "run_id" TEXT,
    "run_link" TEXT,
    "status" TEXT,

--- a/mlflow_cratedb/patch/mlflow/model.py
+++ b/mlflow_cratedb/patch/mlflow/model.py
@@ -9,12 +9,18 @@ def polyfill_uniqueness_constraints():
 
     TODO: Submit patch to `crate-python`, to be enabled by a
           dialect parameter `crate_polyfill_unique` or such.
+
+    TODO: There are two more unique constraints defined on the MLflow data model.
+          - SqlExperimentPermission: "experiment_id", "user_id"
+          - SqlRegisteredModelPermission: "name", "user_id"
     """
+    from mlflow.server.auth.db.models import SqlUser
     from mlflow.store.model_registry.dbmodels.models import SqlRegisteredModel
     from mlflow.store.tracking.dbmodels.models import SqlExperiment
 
     listen(SqlExperiment, "before_insert", check_uniqueness_factory(SqlExperiment, "name"))
     listen(SqlRegisteredModel, "before_insert", check_uniqueness_factory(SqlRegisteredModel, "name"))
+    listen(SqlUser, "before_insert", check_uniqueness_factory(SqlUser, "username"))
 
 
 def polyfill_refresh_after_dml():

--- a/mlflow_cratedb/patch/mlflow/model.py
+++ b/mlflow_cratedb/patch/mlflow/model.py
@@ -10,9 +10,11 @@ def polyfill_uniqueness_constraints():
     TODO: Submit patch to `crate-python`, to be enabled by a
           dialect parameter `crate_polyfill_unique` or such.
     """
+    from mlflow.store.model_registry.dbmodels.models import SqlRegisteredModel
     from mlflow.store.tracking.dbmodels.models import SqlExperiment
 
     listen(SqlExperiment, "before_insert", check_uniqueness_factory(SqlExperiment, "name"))
+    listen(SqlRegisteredModel, "before_insert", check_uniqueness_factory(SqlRegisteredModel, "name"))
 
 
 def polyfill_refresh_after_dml():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ develop = [
   "mypy==1.6.1",
   "poethepoet<1",
   "pyproject-fmt<1.4",
-  "ruff==0.1.1",
+  "ruff==0.1.3",
   "validate-pyproject<0.16",
 ]
 examples = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ develop = [
   "black<24",
   "mypy==1.6.1",
   "poethepoet<1",
-  "pyproject-fmt<1.3",
+  "pyproject-fmt<1.4",
   "ruff==0.1.1",
   "validate-pyproject<0.16",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ develop = [
 ]
 examples = [
   "salesforce-merlion<2.1",
-  "pycaret[analysis,models,tuner,parallel,test]==3.1.0"
+  "pycaret[analysis,models,tuner,parallel,test]==3.1.0",
   "werkzeug==2.2.3"
 ]
 release = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ dependencies = [
   "crash",
   "crate[sqlalchemy]>=0.34",
   "cratedb-toolkit==0.0.1",
-  "mlflow==2.7.1",
+  "mlflow==2.8",
   "sqlparse<0.5",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,7 @@ develop = [
 ]
 examples = [
   "salesforce-merlion<2.1",
+  "pycaret[full]==3.1.0"
 ]
 release = [
   "build<2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,8 @@ develop = [
 ]
 examples = [
   "salesforce-merlion<2.1",
-  "pycaret[full]==3.1.0"
+  "pycaret[analysis,models,tuner,parallel,test]==3.1.0"
+  "werkzeug==2.2.3"
 ]
 release = [
   "build<2",

--- a/release/oci-runtime/Dockerfile
+++ b/release/oci-runtime/Dockerfile
@@ -4,7 +4,7 @@
 # - https://vsupalov.com/buildkit-cache-mount-dockerfile/
 # - https://github.com/FernandoMiguel/Buildkit#mounttypecache
 
-FROM python:3.11-slim-bullseye
+FROM python:3.10-slim-bullseye
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV TERM linux

--- a/release/oci-server/Dockerfile
+++ b/release/oci-server/Dockerfile
@@ -4,7 +4,7 @@
 # - https://vsupalov.com/buildkit-cache-mount-dockerfile/
 # - https://github.com/FernandoMiguel/Buildkit#mounttypecache
 
-FROM python:3.11-slim-bullseye
+FROM python:3.10-slim-bullseye
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV TERM linux

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -133,8 +133,7 @@ def test_tracking_merlion(reset_database, engine: sa.Engine, tracking_store: Sql
 
 @pytest.mark.examples
 @pytest.mark.slow
-def test_tracking_pycaret(reset_database, engine: sa.Engine,
-                          tracking_store: SqlAlchemyStore, db_uri):
+def test_tracking_pycaret(reset_database, engine: sa.Engine, tracking_store: SqlAlchemyStore, db_uri):
     """
     Run a real experiment program, reporting to an MLflow Tracking Server.
     Verify that the database has been populated appropriately.
@@ -158,10 +157,7 @@ def test_tracking_pycaret(reset_database, engine: sa.Engine,
     ]
 
     logger.info("Starting server")
-    with process(cmd_server,
-                 stdout=sys.stdout.buffer,
-                 stderr=sys.stderr.buffer,
-                 close_fds=True) as server_process:
+    with process(cmd_server, stdout=sys.stdout.buffer, stderr=sys.stderr.buffer, close_fds=True) as server_process:
         logger.info(f"Started server with process id: {server_process.pid}")
         # TODO: Wait for HTTP response.
         time.sleep(4)
@@ -169,36 +165,32 @@ def test_tracking_pycaret(reset_database, engine: sa.Engine,
         # Invoke example program.
         logger.info("Starting client")
         with process(
-                cmd_client,
-                env={"MLFLOW_TRACKING_URI": MLFLOW_TRACKING_URI_SERVER},
-                stdout=sys.stdout.buffer,
-                stderr=sys.stderr.buffer,
+            cmd_client,
+            env={"MLFLOW_TRACKING_URI": MLFLOW_TRACKING_URI_SERVER},
+            stdout=sys.stdout.buffer,
+            stderr=sys.stderr.buffer,
         ) as client_process:
             client_process.wait(timeout=480)
             assert client_process.returncode == 0
 
     with tracking_store.ManagedSessionMaker() as session:
         # We have 2 experiments - one for "Default" experiment and one for the example
-        assert session.query(
-            SqlExperiment).count() == 2, "experiments should have 2 rows"
+        assert session.query(SqlExperiment).count() == 2, "experiments should have 2 rows"
         # We have 32 distinct runs in the experiment which produced metrics
-        assert (session.query(sa.func.count(sa.distinct(
-            SqlMetric.run_uuid))).scalar() == 32
-                ), "metrics should have 32 distinct run_uuid"
+        assert (
+            session.query(sa.func.count(sa.distinct(SqlMetric.run_uuid))).scalar() == 32
+        ), "metrics should have 32 distinct run_uuid"
         # We have 33 runs in total (1 parent + 32 child runs)
         assert session.query(SqlRun).count() == 33, "runs should have 33 rows"
         # We have 33 distinct runs which have parameters (1 parent + 32 child runs)
-        assert (session.query(sa.func.count(sa.distinct(
-            SqlParam.run_uuid))).scalar() == 33
-                ), "params should have 33 distinct run_uuid"
+        assert (
+            session.query(sa.func.count(sa.distinct(SqlParam.run_uuid))).scalar() == 33
+        ), "params should have 33 distinct run_uuid"
         # We have one model registered
-        assert session.query(SqlRegisteredModel).count(
-        ) == 1, "registered_models should have 1 row"
+        assert session.query(SqlRegisteredModel).count() == 1, "registered_models should have 1 row"
 
     with engine.begin() as conn:
         # Test the demo data to make sure it was loaded correctly. No refresh required, as the example refreshes
-        demo_data = conn.execute(
-            sa.text("SELECT count(*) as ct FROM doc.sales_data_for_forecast")
-        ).fetchone()
+        demo_data = conn.execute(sa.text("SELECT count(*) as ct FROM doc.sales_data_for_forecast")).fetchone()
 
         assert demo_data[0] == 9491, "demo data should have 9491 rows"

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -5,7 +5,8 @@ from pathlib import Path
 
 import pytest
 import sqlalchemy as sa
-from mlflow.store.tracking.dbmodels.models import SqlExperiment, SqlMetric, SqlParam
+from mlflow.store.model_registry.dbmodels.models import SqlRegisteredModel
+from mlflow.store.tracking.dbmodels.models import SqlExperiment, SqlMetric, SqlParam, SqlRun
 from mlflow.store.tracking.sqlalchemy_store import SqlAlchemyStore
 
 from tests.util import process
@@ -128,3 +129,76 @@ def test_tracking_merlion(reset_database, engine: sa.Engine, tracking_store: Sql
             ),
         )
         assert anomalies_generated.rowcount >= 1
+
+
+@pytest.mark.examples
+@pytest.mark.slow
+def test_tracking_pycaret(reset_database, engine: sa.Engine,
+                          tracking_store: SqlAlchemyStore, db_uri):
+    """
+    Run a real experiment program, reporting to an MLflow Tracking Server.
+    Verify that the database has been populated appropriately.
+
+    Here, `MLFLOW_TRACKING_URI` will be the HTTP URL of the Tracking Server,
+    i.e. the program will submit events and metrics to it, wrapping the
+    connection to CrateDB.
+    """
+    tracking_pycaret = get_example_program_path("tracking_pycaret.py")
+    cmd_server = [
+        "mlflow-cratedb",
+        "server",
+        "--workers=1",
+        f"--backend-store-uri={db_uri}",
+        "--gunicorn-opts='--log-level=debug'",
+    ]
+
+    cmd_client = [
+        sys.executable,
+        tracking_pycaret,
+    ]
+
+    logger.info("Starting server")
+    with process(cmd_server,
+                 stdout=sys.stdout.buffer,
+                 stderr=sys.stderr.buffer,
+                 close_fds=True) as server_process:
+        logger.info(f"Started server with process id: {server_process.pid}")
+        # TODO: Wait for HTTP response.
+        time.sleep(4)
+
+        # Invoke example program.
+        logger.info("Starting client")
+        with process(
+                cmd_client,
+                env={"MLFLOW_TRACKING_URI": MLFLOW_TRACKING_URI_SERVER},
+                stdout=sys.stdout.buffer,
+                stderr=sys.stderr.buffer,
+        ) as client_process:
+            client_process.wait(timeout=480)
+            assert client_process.returncode == 0
+
+    with tracking_store.ManagedSessionMaker() as session:
+        # We have 2 experiments - one for "Default" experiment and one for the example
+        assert session.query(
+            SqlExperiment).count() == 2, "experiments should have 2 rows"
+        # We have 32 distinct runs in the experiment which produced metrics
+        assert (session.query(sa.func.count(sa.distinct(
+            SqlMetric.run_uuid))).scalar() == 32
+                ), "metrics should have 32 distinct run_uuid"
+        # We have 33 runs in total (1 parent + 32 child runs)
+        assert session.query(SqlRun).count() == 33, "runs should have 33 rows"
+        # We have 33 distinct runs which have parameters (1 parent + 32 child runs)
+        assert (session.query(sa.func.count(sa.distinct(
+            SqlParam.run_uuid))).scalar() == 33
+                ), "params should have 33 distinct run_uuid"
+        # We have one model registered
+        assert session.query(SqlRegisteredModel).count(
+        ) == 1, "registered_models should have 1 row"
+
+    with engine.begin() as conn:
+        # Test the demo data to make sure it was loaded correctly. No refresh required, as the example refreshes
+        demo_data = conn.execute(
+            sa.text("SELECT count(*) as ct FROM doc.sales_data_for_forecast")
+        ).fetchone()
+
+        assert demo_data[0] == 9491, "demo data should have 9491 rows"

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -1128,13 +1128,13 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
     def test_log_param_max_length_value(self):
         run = self._run_factory()
         tkey = "blahmetric"
-        tval = "x" * 500
+        tval = "x" * 6000
         param = entities.Param(tkey, tval)
         self.store.log_param(run.info.run_id, param)
         run = self.store.get_run(run.info.run_id)
         assert run.data.params[tkey] == str(tval)
         with pytest.raises(MlflowException, match="exceeded length"):
-            self.store.log_param(run.info.run_id, entities.Param(tkey, "x" * 1000))
+            self.store.log_param(run.info.run_id, entities.Param(tkey, "x" * 6001))
 
     @pytest.mark.skip("[FIXME] ColumnValidationException"
                       "[Validation failed for experiment_id: Updating a primary key is not supported]")
@@ -2744,11 +2744,11 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
 
     def test_log_batch_params_max_length_value(self):
         run = self._run_factory()
-        param_entities = [Param("long param", "x" * 500), Param("short param", "xyz")]
-        expected_param_entities = [Param("long param", "x" * 500), Param("short param", "xyz")]
+        param_entities = [Param("long param", "x" * 6000), Param("short param", "xyz")]
+        expected_param_entities = [Param("long param", "x" * 6000), Param("short param", "xyz")]
         self.store.log_batch(run.info.run_id, [], param_entities, [])
         self._verify_logged(self.store, run.info.run_id, [], expected_param_entities, [])
-        param_entities = [Param("long param", "x" * 1000)]
+        param_entities = [Param("long param", "x" * 6001)]
         with pytest.raises(MlflowException, match="exceeded length"):
             self.store.log_batch(run.info.run_id, [], param_entities, [])
 

--- a/tests/test_tracking_issues.py
+++ b/tests/test_tracking_issues.py
@@ -1,0 +1,57 @@
+import os
+import re
+
+import mlflow
+import mlflow.sklearn
+from mlflow.models import Model
+from mlflow.models.model import ModelInfo
+
+
+def test_log_model_twice(tracking_store, reset_database):
+    """
+    Problem
+    -------
+    Problems when calling `mlflow.sklearn.log_model` twice.
+    UPDATE statement on table 'registered_models' expected to update 1 row(s); 2 were matched.
+
+    Solution
+    --------
+    Add a uniqueness constraint.
+
+    References
+    ----------
+    - https://github.com/crate-workbench/mlflow-cratedb/issues/46
+    """
+
+    # Activate backend for tracking.
+    os.environ["MLFLOW_TRACKING_URI"] = tracking_store.db_uri
+
+    # Every experiment needs a name.
+    mlflow.set_experiment("test_log_model")
+
+    artifact_path = "testdrive-artifact"
+    registered_model_name = "testdrive-artifact-model"
+    sk_model = None
+
+    # Emulate `mlflow.sklearn.log_model`.
+    def log_model(metadata=None):
+        return Model.log(
+            artifact_path=artifact_path,
+            flavor=mlflow.sklearn,
+            registered_model_name=registered_model_name,
+            await_registration_for=0.01,
+            metadata=metadata,
+            sk_model=sk_model,
+        )
+
+    # Verify that the model incurred an update.
+
+    model_info = log_model(metadata={"status": "update-1", "training": True})
+    assert isinstance(model_info, ModelInfo)
+    assert re.match(r".*runs:/[0-9a-z]+/testdrive-artifact.*", model_info.model_uri)
+    assert model_info.metadata == {"status": "update-1", "training": True}
+
+    model_info = log_model(metadata={"status": "update-2", "knowledge": "excellent"})
+    assert isinstance(model_info, ModelInfo)
+    assert re.match(r".*runs:/[0-9a-z]+/testdrive-artifact.*", model_info.model_uri)
+    assert model_info.metadata == {"status": "update-2", "knowledge": "excellent"}


### PR DESCRIPTION
Provides an example for how to use pycaret to automatically benchmark, select and register a timeseries forecasting model. 
Uses sales forecasting as example data.

Based on the canonical example ``track_merlion.py`` from @amotl .

Requires ``MLFLOW_TRACKING_URI`` to be set, as the example attempts to register the final model with MLflow. This does not work, if only file-based tracking is available.