### PR TITLE
Downgrade to Python 3.10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.11"]
+        python-version: ["3.10"]
 
     env:
       OS: ${{ matrix.os }}

--- a/.github/workflows/oci-server.yml
+++ b/.github/workflows/oci-server.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.10"
           architecture: "x64"
           cache: "pip"
           cache-dependency-path: "pyproject.toml"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@
 
 ## in progress
 - Fix uniqueness constraint with `SqlRegisteredModel.name`. Thanks, @andnig.
+- Downgrade to Python 3.10. A few packages like PyCaret are not ready for
+  Python 3.11 yet. Thanks, @andnig.
 
 ## 2023-10-11 0.2.0
 - Update to [MLflow 2.7](https://github.com/mlflow/mlflow/releases/tag/v2.7.0)

--- a/release/oci-runtime/Dockerfile
+++ b/release/oci-runtime/Dockerfile
@@ -4,7 +4,7 @@
 # - https://vsupalov.com/buildkit-cache-mount-dockerfile/
 # - https://github.com/FernandoMiguel/Buildkit#mounttypecache
 
-FROM python:3.11-slim-bullseye
+FROM python:3.10-slim-bullseye
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV TERM linux

--- a/release/oci-server/Dockerfile
+++ b/release/oci-server/Dockerfile
@@ -4,7 +4,7 @@
 # - https://vsupalov.com/buildkit-cache-mount-dockerfile/
 # - https://github.com/FernandoMiguel/Buildkit#mounttypecache
 
-FROM python:3.11-slim-bullseye
+FROM python:3.10-slim-bullseye
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV TERM linux


### PR DESCRIPTION
## About

A few packages in the ML arena, like PyCaret, are apparently not ready for Python 3.11 yet.

## Details

@andnig has been tripped by this when trying to bring in an example about MLflow and PyCaret. It does not support Python 3.11 yet.

- GH-45
- https://github.com/pycaret/pycaret/pull/3756

## Thoughts

It does not mean that the software will stop working on Python 3.11. It is only that we test Python 3.10 by default, and also build and ship the OCI images with Python 3.10 now, for better compatibility. I don't want to open the box of running a test matrix now, and would like to follow the suggestion by @andnig without further ado.

/cc @hammerhead, @ckurze