### PR TITLE
Update to MLflow 2.8.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 
 ## in progress
+- Update to MLflow 2.8.0
 
 ## 2023-11-01 v2.7.1
 - Fix uniqueness constraint with `SqlRegisteredModel.name`. Thanks, @andnig.

--- a/mlflow_cratedb/adapter/ddl/cratedb.sql
+++ b/mlflow_cratedb/adapter/ddl/cratedb.sql
@@ -72,6 +72,7 @@ CREATE TABLE IF NOT EXISTS "model_versions" (
    "user_id" TEXT,
    "current_stage" TEXT,
    "source" TEXT,
+   "storage_location" TEXT,
    "run_id" TEXT,
    "run_link" TEXT,
    "status" TEXT,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ dependencies = [
   "crash",
   "crate[sqlalchemy]>=0.34",
   "cratedb-toolkit==0.0.1",
-  "mlflow==2.7.1",
+  "mlflow==2.8",
   "sqlparse<0.5",
 ]
 

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -1128,13 +1128,13 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
     def test_log_param_max_length_value(self):
         run = self._run_factory()
         tkey = "blahmetric"
-        tval = "x" * 500
+        tval = "x" * 6000
         param = entities.Param(tkey, tval)
         self.store.log_param(run.info.run_id, param)
         run = self.store.get_run(run.info.run_id)
         assert run.data.params[tkey] == str(tval)
         with pytest.raises(MlflowException, match="exceeded length"):
-            self.store.log_param(run.info.run_id, entities.Param(tkey, "x" * 1000))
+            self.store.log_param(run.info.run_id, entities.Param(tkey, "x" * 6001))
 
     @pytest.mark.skip("[FIXME] ColumnValidationException"
                       "[Validation failed for experiment_id: Updating a primary key is not supported]")
@@ -2744,11 +2744,11 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
 
     def test_log_batch_params_max_length_value(self):
         run = self._run_factory()
-        param_entities = [Param("long param", "x" * 500), Param("short param", "xyz")]
-        expected_param_entities = [Param("long param", "x" * 500), Param("short param", "xyz")]
+        param_entities = [Param("long param", "x" * 6000), Param("short param", "xyz")]
+        expected_param_entities = [Param("long param", "x" * 6000), Param("short param", "xyz")]
         self.store.log_batch(run.info.run_id, [], param_entities, [])
         self._verify_logged(self.store, run.info.run_id, [], expected_param_entities, [])
-        param_entities = [Param("long param", "x" * 1000)]
+        param_entities = [Param("long param", "x" * 6001)]
         with pytest.raises(MlflowException, match="exceeded length"):
             self.store.log_batch(run.info.run_id, [], param_entities, [])
 


### PR DESCRIPTION
## About

MLflow 2.8.0 was released three days ago.
https://github.com/mlflow/mlflow/releases/tag/v2.8.0

## References

- GH-50

/cc @ckurze