### PR TITLE
Fix uniqueness constraint with `.auth.db.models.SqlUser.username`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 
 ## in progress
 - Update to MLflow 2.8.0
+- Fix uniqueness constraint with `mlflow.server.auth.db.models.SqlUser.username`.
 
 ## 2023-11-01 v2.7.1
 - Fix uniqueness constraint with `SqlRegisteredModel.name`. Thanks, @andnig.

--- a/mlflow_cratedb/patch/mlflow/model.py
+++ b/mlflow_cratedb/patch/mlflow/model.py
@@ -9,12 +9,18 @@ def polyfill_uniqueness_constraints():
 
     TODO: Submit patch to `crate-python`, to be enabled by a
           dialect parameter `crate_polyfill_unique` or such.
+
+    TODO: There are two more unique constraints defined on the MLflow data model.
+          - SqlExperimentPermission: "experiment_id", "user_id"
+          - SqlRegisteredModelPermission: "name", "user_id"
     """
+    from mlflow.server.auth.db.models import SqlUser
     from mlflow.store.model_registry.dbmodels.models import SqlRegisteredModel
     from mlflow.store.tracking.dbmodels.models import SqlExperiment
 
     listen(SqlExperiment, "before_insert", check_uniqueness_factory(SqlExperiment, "name"))
     listen(SqlRegisteredModel, "before_insert", check_uniqueness_factory(SqlRegisteredModel, "name"))
+    listen(SqlUser, "before_insert", check_uniqueness_factory(SqlUser, "username"))
 
 
 def polyfill_refresh_after_dml():


### PR DESCRIPTION
## About

Just a minor followup to GH-46.

## Trivia

The first CI run on this patch experienced an interesting fluke with CrateDB. We added a report at GH-53.

