### PR TITLE
Fix two more uniqueness constraints in SQLAlchemy data model

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,10 @@
   Note that it is always advised to create backups of your database content.
   This is an excellent opportunity to do that.
 
-- Fix uniqueness constraint with `mlflow.server.auth.db.models.SqlUser.username`.
+- Fix uniqueness constraints
+  - `mlflow.server.auth.db.models.SqlUser.username`.
+  - `m.s.a.d.m.SqlExperimentPermission`: "experiment_id", "user_id"
+  - `m.s.a.d.m.SqlRegisteredModelPermission`: "name", "user_id"
 
 ## 2023-11-01 v2.7.1
 - Fix uniqueness constraint with `SqlRegisteredModel.name`. Thanks, @andnig.

--- a/mlflow_cratedb/patch/mlflow/model.py
+++ b/mlflow_cratedb/patch/mlflow/model.py
@@ -14,12 +14,24 @@ def polyfill_uniqueness_constraints():
           - SqlExperimentPermission: "experiment_id", "user_id"
           - SqlRegisteredModelPermission: "name", "user_id"
     """
-    from mlflow.server.auth.db.models import SqlUser
+    from mlflow.server.auth.db.models import SqlExperimentPermission, SqlRegisteredModelPermission, SqlUser
     from mlflow.store.model_registry.dbmodels.models import SqlRegisteredModel
     from mlflow.store.tracking.dbmodels.models import SqlExperiment
 
     listen(SqlExperiment, "before_insert", check_uniqueness_factory(SqlExperiment, "name"))
+    listen(
+        SqlExperimentPermission,
+        "before_insert",
+        check_uniqueness_factory(SqlExperimentPermission, "experiment_id", "user_id"),
+    )
+
     listen(SqlRegisteredModel, "before_insert", check_uniqueness_factory(SqlRegisteredModel, "name"))
+    listen(
+        SqlRegisteredModelPermission,
+        "before_insert",
+        check_uniqueness_factory(SqlRegisteredModelPermission, "name", "user_id"),
+    )
+
     listen(SqlUser, "before_insert", check_uniqueness_factory(SqlUser, "username"))
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ dynamic = [
 dependencies = [
   "crash",
   "crate[sqlalchemy]>=0.34",
-  "cratedb-toolkit==0.0.1",
+  "cratedb-toolkit==0.0.2",
   "mlflow==2.8",
   "sqlparse<0.5",
 ]
@@ -93,8 +93,8 @@ develop = [
   "validate-pyproject<0.16",
 ]
 examples = [
+  "pycaret[analysis,models,parallel,test,tuner]==3.1",
   "salesforce-merlion<2.1",
-  "pycaret[analysis,models,tuner,parallel,test]==3.1.0",
   "werkzeug==2.2.3",
 ]
 release = [


### PR DESCRIPTION
## About

GH-46 and GH-52 reported and fixed missing uniqueness constraints on the SQLAlchemy data model. This patch adds two more, based on recent improvements from https://github.com/crate-workbench/cratedb-toolkit/pull/70.

- SqlExperimentPermission: "experiment_id", "user_id"
- SqlRegisteredModelPermission: "name", "user_id"

/cc @hlcianfagna 
