### PR TITLE
Optimize OCI image sizes

### DIFF
--- a/release/oci-runtime/Dockerfile
+++ b/release/oci-runtime/Dockerfile
@@ -12,26 +12,29 @@ ENV TERM linux
 # Install Git, it is needed for both `versioningit`, and MLflow.
 RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
 
-# Install distribution packages, with caching.
-RUN \
-    --mount=type=cache,id=apt,sharing=locked,target=/var/cache/apt \
-    --mount=type=cache,id=apt,sharing=locked,target=/var/lib/apt \
-    true \
-    && apt-get update \
-    && apt-get install --no-install-recommends --no-install-suggests --yes gcc git openjdk-11-jre python3-dev
-
 # Copy sources
 COPY . /src
 
-# Install package, with caching of dependency packages.
+# 1. Install distribution packages, with caching.
+# NB: installing gcc is required in order to build a wheel file
+# for psutil, which is a dependency of mlflow.
+# The binaries for psutil do not support Python 3.10, requiring
+# a build from source. psutil has a large amount of cython within
+# its code base, necessitating gcc being present in the image.
+
+# 2. Install package, with caching of dependency packages.
+
+# 3. Uninstall distribution packages again.
+
 RUN \
+    --mount=type=cache,id=apt,sharing=locked,target=/var/cache/apt \
+    --mount=type=cache,id=apt,sharing=locked,target=/var/lib/apt \
     --mount=type=cache,id=pip,target=/root/.cache/pip \
     true \
-    && pip install --use-pep517 --prefer-binary '/src[examples]'
-
-# Uninstall distribution packages again.
-# TODO: Optimize - previous layers have already been written.
-RUN apt-get --yes remove --purge gcc git python3-dev && apt-get --yes autoremove
+    && apt-get update \
+    && apt-get install --no-install-recommends --no-install-suggests --yes gcc git python3-dev openjdk-11-jre \
+    && pip install --use-pep517 --prefer-binary '/src[examples]' \
+    && apt-get --yes remove --purge gcc git python3-dev && apt-get --yes autoremove
 
 # Purge /src and /tmp directories.
 RUN rm -rf /src /tmp/*

--- a/release/oci-server/Dockerfile
+++ b/release/oci-server/Dockerfile
@@ -12,31 +12,29 @@ ENV TERM linux
 # Install Git, it is needed for both `versioningit`, and MLflow.
 RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
 
-# Install distribution packages, with caching.
+# Copy sources
+COPY . /src
+
+# 1. Install distribution packages, with caching.
 # NB: installing gcc is required in order to build a wheel file
 # for psutil, which is a dependency of mlflow.
 # The binaries for psutil do not support Python 3.10, requiring
 # a build from source. psutil has a large amount of cython within
 # its code base, necessitating gcc being present in the image.
+
+# 2. Install package, with caching of dependency packages.
+
+# 3. Uninstall distribution packages again.
+
 RUN \
     --mount=type=cache,id=apt,sharing=locked,target=/var/cache/apt \
     --mount=type=cache,id=apt,sharing=locked,target=/var/lib/apt \
-    true \
-    && apt-get update \
-    && apt-get install --no-install-recommends --no-install-suggests --yes gcc git python3-dev
-
-# Copy sources
-COPY . /src
-
-# Install package, with caching of dependency packages.
-RUN \
     --mount=type=cache,id=pip,target=/root/.cache/pip \
     true \
-    && pip install --use-pep517 --prefer-binary '/src'
-
-# Uninstall distribution packages again.
-# TODO: Optimize - previous layers have already been written.
-RUN apt-get --yes remove --purge gcc git python3-dev && apt-get --yes autoremove
+    && apt-get update \
+    && apt-get install --no-install-recommends --no-install-suggests --yes gcc git python3-dev \
+    && pip install --use-pep517 --prefer-binary '/src' \
+    && apt-get --yes remove --purge gcc git python3-dev && apt-get --yes autoremove
 
 # Purge /src and /tmp directories.
 RUN rm -rf /src /tmp/*


### PR DESCRIPTION
## About

Now that we need `gcc` to satisfy the `psutil` dependency of MLflow, we uninstall it right away. In order that this makes sense, all commands (install/uninstall) need to be done in one run.
