### PR TITLE
Examples: Use `refresh_table` to synchronize CrateDB write operations

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}
 
-    # https://docs.github.com/en/free-pro-team@latest/actions/guides/about-service-containers
+    # https://docs.github.com/en/actions/using-containerized-services/about-service-containers
     services:
       cratedb:
         image: crate/crate:nightly

--- a/examples/tracking_merlion.py
+++ b/examples/tracking_merlion.py
@@ -112,6 +112,20 @@ def import_data(data_table_name: str, anomalies_table_name: str):
         )
 
 
+def refresh_table(table_name: str):
+    """
+    Flush/Synchronize CrateDB write operations.
+    Refresh the table, to make sure the data is up-to-date.
+
+    https://cratedb.com/docs/crate/reference/en/latest/sql/statements/refresh.html
+    """
+
+    with connect_database() as conn:
+        cursor = conn.cursor()
+        cursor.execute(f"REFRESH TABLE {table_name}")
+        cursor.close()
+
+
 def read_data(table_name: str) -> pd.DataFrame:
     """
     Read data from database into pandas DataFrame.
@@ -248,6 +262,9 @@ def main():
     # Provision data to operate on, only once.
     if not table_exists(data_table):
         import_data(data_table, anomalies_table)
+
+        # Flush/Synchronize CrateDB write operations.
+        refresh_table(data_table)
 
     # Read data into pandas DataFrame.
     data = read_data(data_table)

--- a/examples/tracking_pycaret.py
+++ b/examples/tracking_pycaret.py
@@ -122,8 +122,12 @@ def import_data(data_table_name: str):
 
 
 def refresh_table(table_name: str):
-    """Refresh the table, to make sure the data is up to date.
-    Required due to crate being eventually consistent."""
+    """
+    Flush/Synchronize CrateDB write operations.
+    Refresh the table, to make sure the data is up-to-date.
+
+    https://cratedb.com/docs/crate/reference/en/latest/sql/statements/refresh.html
+    """
 
     with connect_database() as conn:
         cursor = conn.cursor()
@@ -204,7 +208,7 @@ def main():
     if not table_exists(data_table):
         import_data(data_table)
 
-        # Refresh the table - due to crate's eventual consistency.
+        # Flush/Synchronize CrateDB write operations.
         refresh_table(data_table)
 
     # Read data into pandas DataFrame.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ default-tag = "0.0.0"
 name = "mlflow-cratedb"
 description = "MLflow adapter for CrateDB"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.8,<3.12"
 license = {text = "Apache License 2.0"}
 keywords = [
   "ai",
@@ -86,14 +86,14 @@ dependencies = [
 [project.optional-dependencies]
 develop = [
   "black<24",
-  "mypy==1.7.0",
+  "mypy==1.7",
   "poethepoet<1",
   "pyproject-fmt<1.6",
   "ruff==0.1.6",
   "validate-pyproject<0.16",
 ]
 examples = [
-  "pycaret[analysis,models,parallel,test,tuner]==3.2.0; platform_machine != 'aarch64'",
+  'pycaret[analysis,models,parallel,test,tuner]==3.2; platform_machine != "aarch64"',
   "salesforce-merlion<2.1",
   "werkzeug==2.2.3",
 ]
@@ -102,7 +102,7 @@ release = [
   "twine<5",
 ]
 test = [
-  "psutil==5.9.2",  # This version has binary wheels for Python 3.10.
+  "psutil==5.9.2", # This version has binary wheels for Python 3.10.
   "pytest<8",
   "pytest-cov<5",
 ]


### PR DESCRIPTION
## About

Within the example programs, use `REFRESH TABLE ...` to synchronize CrateDB write operations before advancing to subsequent operations. Fixes GH-49.

## Misc

Two more maintenance commits, nothing special.
