### PR TITLE
CI: Increase heap memory size for CrateDB to 4 GB

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,6 +40,8 @@ jobs:
         ports:
           - 4200:4200
           - 5432:5432
+        env:
+          CRATE_HEAP_SIZE: 4g
 
     name: Python ${{ matrix.python-version }} on OS ${{ matrix.os }}
     steps:


### PR DESCRIPTION
## About
This may help in situations where the integration tests are heavy on
memory use, and where we observed flaky behaviour on CI.

According to GitHub's documentation, standard runners offer 16 GB of
RAM, so dedicating 4 GB to CrateDB will not blow up the main memory.

-- https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories

## References
- GH-53
