### PR TITLE
CI: Run integration tests each night

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,10 @@ on:
   # Allow job to be triggered manually.
   workflow_dispatch:
 
+  # Run job each night after CrateDB nightly has been published.
+  schedule:
+    - cron: '0 3 * * *'
+
 # Cancel in-progress jobs when pushing to the same branch.
 concurrency:
   cancel-in-progress: true


### PR DESCRIPTION
## About

This supports better discovering eventual regressions at CrateDB, and also adds additional churn to the repository, in order to detect other anomalies.