### PR TITLE
Revert "CI: Build OCI images on PRs again"

### DIFF
--- a/.github/workflows/oci-runtime.yml
+++ b/.github/workflows/oci-runtime.yml
@@ -16,7 +16,7 @@ on:
   # Remark: Activate only when needed, it will eat a lot of resources. The alternative
   #         is to build manually / on-demand, by using the `workflow_dispatch` feature,
   #         available through the GHA web UI.
-  pull_request: ~
+  # pull_request: ~
 
   # Produce a nightly image every day at 6 a.m. CEST.
   schedule:

--- a/.github/workflows/oci-server.yml
+++ b/.github/workflows/oci-server.yml
@@ -16,7 +16,7 @@ on:
   # Remark: Activate only when needed, it will eat a lot of resources. The alternative
   #         is to build manually / on-demand, by using the `workflow_dispatch` feature,
   #         available through the GHA web UI.
-  pull_request: ~
+  # pull_request: ~
 
   # Produce a nightly image every day at 6 a.m. CEST.
   schedule:


### PR DESCRIPTION
## About
This reverts commit a1356ec72d692ddd479db8addabc8d4158c0ae02. It means we are not always building OCI images on each PR, because it is a rather heavy process.
