### PR TITLE
CI: Update to codecov-action@v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,10 +72,12 @@ jobs:
         poe check
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:
         files: ./coverage.xml
         flags: unittests
         env_vars: OS,PYTHON
         name: codecov-umbrella
-        fail_ci_if_error: false
+        fail_ci_if_error: true


### PR DESCRIPTION
## Background
- GH-97

## About
> Tokenless uploading is unsupported. However, PRs made from forks to
> the upstream public repos will support tokenless (e.g. contributors to
> OS projects do not need the upstream repo's Codecov token). This doc
> shows instructions on how to add the Codecov token.
>
> -- https://docs.codecov.com/docs/adding-the-codecov-token#github-actions

## References
- https://github.com/panodata/aika/pull/55
