### PR TITLE
Update MLflow from 2.10.2 to 2.11.3

### DIFF
--- a/mlflow_cratedb/adapter/ddl/cratedb.sql
+++ b/mlflow_cratedb/adapter/ddl/cratedb.sql
@@ -59,8 +59,7 @@ CREATE TABLE IF NOT EXISTS "metrics" (
    "timestamp" BIGINT NOT NULL,
    "step" BIGINT NOT NULL,
    "is_nan" BOOLEAN NOT NULL,
-   "run_uuid" TEXT NOT NULL,
-   PRIMARY KEY ("key", "timestamp", "step", "run_uuid", "value", "is_nan")
+   "run_uuid" TEXT NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS "model_versions" (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ dependencies = [
   "crash",
   "crate[sqlalchemy]>=0.34",
   "cratedb-toolkit==0.0.8",
-  "mlflow==2.10.2",
+  "mlflow==2.11.3",
   "sqlparse<0.5",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ dependencies = [
   "crash",
   "crate[sqlalchemy]>=0.34",
   "cratedb-toolkit==0.0.8",
+  "joblib<1.4",
   "mlflow==2.11.3",
   "sqlparse<0.5",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,6 +133,7 @@ skip_gitignore = false
 minversion = "2.0"
 addopts = """
   -rfEX -p pytester --strict-markers --verbosity=3
+  --capture=no
   --cov --cov-report=term-missing --cov-report=xml
   """
 log_level = "DEBUG"

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -173,6 +173,12 @@ def test_tracking_pycaret(reset_database, engine: sa.Engine, tracking_store: Sql
             client_process.wait(timeout=480)
             assert client_process.returncode == 0
 
+    with engine.begin() as conn:
+        conn.execute(sa.text("REFRESH TABLE testdrive.experiments"))
+        conn.execute(sa.text("REFRESH TABLE testdrive.metrics"))
+        conn.execute(sa.text("REFRESH TABLE testdrive.params"))
+        conn.execute(sa.text("REFRESH TABLE doc.sales_data_for_forecast"))
+
     with tracking_store.ManagedSessionMaker() as session:
         # We have 2 experiments - one for "Default" experiment and one for the example
         assert session.query(SqlExperiment).count() == 2, "experiments should have 2 rows"


### PR DESCRIPTION
## About

Updating to MLflow 2.11 does not work without further ado.

- GH-121

Minor adjustments have been required to satisfy the test cases.

## See Also
- GH-125
