### PR TITLE
Fix incompatibility with Python 3.11.9 and Dask

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 
 ## in progress
+- Fix incompatibility with Python 3.11.9
 
 ## 2024-02-13 v2.10.2
 - Update to [MLflow 2.10.2](https://github.com/mlflow/mlflow/releases/tag/v2.10.2)

--- a/README.md
+++ b/README.md
@@ -39,8 +39,10 @@ The [MLflow Tracking] subsystem is about recording and querying experiments, acr
 code, data, config, and results.
 
 The MLflow adapter for CrateDB can be used in different ways. Please refer
-to the [handbook], the documentation about [container usage], and the
-[hands-on guidelines].
+to the [handbook], and the documentation about [container usage].
+
+For more general information, see [Machine Learning with CrateDB]
+and [examples about MLflow and CrateDB].
 
 
 ## Development
@@ -87,11 +89,12 @@ ML experiment programs, using [Merlion] and [PyCaret].
 [CrateDB Cloud]: https://console.cratedb.cloud/
 [Create an issue]: https://github.com/crate-workbench/mlflow-cratedb/issues
 [development sandbox]: https://github.com/crate-workbench/mlflow-cratedb/blob/main/docs/development.md
+[examples about MLflow and CrateDB]: https://github.com/crate/cratedb-examples/tree/main/topic/machine-learning/mlops-mlflow
 [handbook]: https://github.com/crate-workbench/mlflow-cratedb/blob/main/docs/handbook.md
-[hands-on guidelines]: https://github.com/crate/cratedb-examples/blob/main/framework/mlflow/readme.md
 [Harutaka Kawamura]: https://github.com/harupy
 [install a development sandbox]: https://github.com/crate-workbench/mlflow-cratedb/blob/main/docs/development.md
 [LICENSE]: https://github.com/crate-workbench/mlflow-cratedb/blob/main/LICENSE
+[Machine Learning with CrateDB]: https://cratedb.com/docs/guide/domain/ml/
 [managed on GitHub]: https://github.com/crate-workbench/mlflow-cratedb
 [Merlion]: https://github.com/salesforce/Merlion
 [MLflow]: https://mlflow.org/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ dependencies = [
   "crash",
   "crate[sqlalchemy]>=0.34",
   "cratedb-toolkit==0.0.10",
+  "dask>=2024.4.1",
   "joblib<1.4",
   "mlflow==2.11.3",
   "sqlparse<0.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ dynamic = [
 dependencies = [
   "crash",
   "crate[sqlalchemy]>=0.34",
-  "cratedb-toolkit==0.0.8",
+  "cratedb-toolkit==0.0.10",
   "joblib<1.4",
   "mlflow==2.11.3",
   "sqlparse<0.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -176,7 +176,7 @@ warn_redundant_casts = true
 [tool.ruff]
 line-length = 120
 
-select = [
+lint.select = [
   # Bandit
   "S",
   # Bugbear
@@ -208,7 +208,7 @@ extend-exclude = [
 ]
 
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "tests/*" = ["S101"]  # Use of `assert` detected
 "tests/conftest.py" = ["E402"]  # Module level import not at top of file
 
@@ -227,7 +227,7 @@ format = [
 ]
 
 lint = [
-  { cmd = "ruff ." },
+  { cmd = "ruff check ." },
   { cmd = "black --check ." },
   { cmd = "validate-pyproject pyproject.toml" },
   { cmd = "mypy" },


### PR DESCRIPTION
- Fix incompatibility with Python 3.11.9 by updating to cratedb-toolkit 0.0.10.
  See also https://github.com/pycaret/pycaret/issues/3960#issuecomment-2045881422.
- Chore: Update Ruff configuration to match more recent versions.
- Update README.
