### PR TITLE
Dependencies: Migrate from `crate[sqlalchemy]` to `sqlalchemy-cratedb`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,11 +77,12 @@ dynamic = [
 
 dependencies = [
   "crash",
-  "crate[sqlalchemy]>=0.34",
-  "cratedb-toolkit==0.0.12",
+  "crate==1.0.0dev0",
+  "cratedb-toolkit>=0.0.13,<0.1",
   "dask>=2024.4.1",
   "joblib!=1.4.0,<1.5",
   "mlflow==2.13.1",
+  "sqlalchemy-cratedb>=0.36.0,<1",
   "sqlparse<0.6",
 ]
 


### PR DESCRIPTION
## About
The [CrateDB SQLAlchemy dialect](https://github.com/crate-workbench/sqlalchemy-cratedb) needs more love, so it was separated from the [DBAPI HTTP driver](https://github.com/crate/crate-python). This patch verifies and concludes the migration.

## References
- https://github.com/crate/roadmap/issues/85
