### PR TITLE
CI: Fix OCI build for ARM by running it on Ubuntu 22

### DIFF
--- a/.github/workflows/oci-runtime.yml
+++ b/.github/workflows/oci-runtime.yml
@@ -38,7 +38,7 @@ env:
 jobs:
 
   oci:
-    runs-on: ubuntu-latest
+    runs-on: "ubuntu-22.04"
     if: ${{ ! (startsWith(github.actor, 'dependabot') || github.event.pull_request.head.repo.fork ) }}
 
     steps:

--- a/.github/workflows/oci-server.yml
+++ b/.github/workflows/oci-server.yml
@@ -37,7 +37,7 @@ env:
 
 jobs:
   build_and_test:
-    runs-on: ubuntu-latest
+    runs-on: "ubuntu-22.04"
 
     steps:
       - name: Acquire sources


### PR DESCRIPTION
## Problem
On Ubuntu 24, this happens when building OCI images for ARM:
```
Processing triggers for libc-bin (2.31-13+deb11u11) ...
qemu: uncaught target signal 11 (Segmentation fault) - core dumped
```

## References
- https://github.com/crate/mlflow-cratedb/issues/208
