### PR TITLE
CI: Validate on Python 3.14

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,7 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
+          - "3.14"
 
     # https://docs.github.com/en/actions/using-containerized-services/about-service-containers
     services:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Communications",
   "Topic :: Database",
   "Topic :: Database :: Database Engines/Servers",


### PR DESCRIPTION
Does MLflow work with Python 3.14 already?