### PR TITLE
Server: Switch from `gunicorn` to `uvicorn` as suggested

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 ## in progress
 - Amalgamation: Started supporting huey jobs that are invoked in subprocesses
 - Model: Added tables `jobs`, `online_scoring_configs`, `scorers`, `scorer_versions`
+- Server: Switched from `gunicorn` to `uvicorn` as suggested
 
 ## 2026-03-29 v3.10.1
 - Updated to [MLflow 3.10.1]

--- a/docs/container.md
+++ b/docs/container.md
@@ -84,7 +84,7 @@ and the web UI, see http://localhost:5000/.
 docker run --rm -it --name=mlflow --link=cratedb --publish=5000:5000 \
   ghcr.io/crate/mlflow-cratedb mlflow-cratedb server \
   --backend-store-uri="${CRATEDB_SQLALCHEMY_URL}" --host=0.0.0.0 \
-  --gunicorn-opts="--log-level=debug"
+  --uvicorn-opts="--log-level=debug"
 ```
 
 Start an experiment program which needs to access both CrateDB and MLflow,

--- a/mlflow_cratedb/patch/mlflow/server.py
+++ b/mlflow_cratedb/patch/mlflow/server.py
@@ -7,7 +7,7 @@ def patch_run_server():
     """
     Intercept `mlflow.server._run_server`, and set `--app-name` to
     a wrapper application. This is needed to run the monkeypatching also
-    within the gunicorn workers.
+    within the gunicorn/uvicorn workers.
     """
     import mlflow.server as server
 

--- a/mlflow_cratedb/server.py
+++ b/mlflow_cratedb/server.py
@@ -1,2 +1,8 @@
 # Intercept server entrypoint for monkeypatching.
-from mlflow.server import app  # noqa: F401
+# ruff: noqa: ERA001
+
+# Use Flask with gunicorn
+# from mlflow.server import app  # noqa: F401
+
+# Use FastAPI with uvicorn
+from mlflow.server.fastapi_app import app  # noqa: F401

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -75,7 +75,7 @@ def test_tracking_merlion(reset_database, engine: sa.Engine, tracking_store: Sql
         "server",
         "--workers=1",
         f"--backend-store-uri={db_uri}",
-        "--gunicorn-opts='--log-level=debug'",
+        "--uvicorn-opts='--log-level=debug'",
     ]
     cmd_client = [
         sys.executable,
@@ -148,7 +148,7 @@ def test_tracking_pycaret(reset_database, engine: sa.Engine, tracking_store: Sql
         "server",
         "--workers=1",
         f"--backend-store-uri={db_uri}",
-        "--gunicorn-opts='--log-level=debug'",
+        "--uvicorn-opts='--log-level=debug'",
     ]
 
     cmd_client = [


### PR DESCRIPTION
Picked up a warning when running the test suite.
```python
/path/to/mlflow_cratedb/patch/mlflow/server.py:22: FutureWarning: We recommend using uvicorn for improved performance. Please use uvicorn by default or specify '--uvicorn-opts' instead of '--gunicorn-opts'.
  return _run_server_dist(*args_effective, **kwargs)
```