### PR TITLE
CI: Skip running tests on Python 3.11-3.13 to save resources

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,9 +30,6 @@ jobs:
           - "ubuntu-latest"
         python-version:
           - "3.10"
-          - "3.11"
-          - "3.12"
-          - "3.13"
           - "3.14"
 
     # https://docs.github.com/en/actions/using-containerized-services/about-service-containers


### PR DESCRIPTION
Just maintenance.