### PR TITLE
OCI: Update MLflow server to use Python 3.14 and Debian 13 (trixie)

### DIFF
--- a/.github/workflows/oci-server.yml
+++ b/.github/workflows/oci-server.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           activate-environment: true
           enable-cache: true
-          python-version: "3.11"
+          python-version: "3.14"
 
       - name: Build wheel package
         run: |

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## in progress
 - Updated to [MLflow 3.12.0]
 - Model: Added tables `guardrails` and `guardrail_configs`
+- OCI: Updated MLflow server to use Python 3.14 and Debian 13 (trixie)
 
 [MLflow 3.12.0]: https://github.com/mlflow/mlflow/blob/master/CHANGELOG.md#3120-2026-05-04
 

--- a/release/oci-server/Dockerfile
+++ b/release/oci-server/Dockerfile
@@ -4,7 +4,7 @@
 # - https://vsupalov.com/buildkit-cache-mount-dockerfile/
 # - https://github.com/FernandoMiguel/Buildkit#mounttypecache
 
-FROM docker.io/python:3.13-slim-bookworm
+FROM docker.io/python:3.14-slim-trixie
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TERM=linux


### PR DESCRIPTION
- Python 3.13 => 3.14
- Debian 12 (bookworm) => 13 (trixie)
