### PR TITLE
OCI: Stop pinning `tonistiigi/binfmt:qemu-v7.0.0-28` in GHA recipe

### DIFF
--- a/.github/workflows/oci-runtime.yml
+++ b/.github/workflows/oci-runtime.yml
@@ -71,8 +71,6 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
-        with:
-          image: tonistiigi/binfmt:qemu-v7.0.0-28
 
       - name: Set up Docker Buildx
         id: buildx

--- a/.github/workflows/oci-server.yml
+++ b/.github/workflows/oci-server.yml
@@ -108,8 +108,6 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
-        with:
-          image: tonistiigi/binfmt:qemu-v7.0.0-28
 
       - name: Set up Docker Buildx
         id: buildx


### PR DESCRIPTION
It was introduced because of previous hiccups, but now is a speed bump when updating to Debian Trixie.
